### PR TITLE
fix: don't refuse safe symlinks when unpacking llama.cpp release archives

### DIFF
--- a/minimax_h3_rewriter/llamacpp.py
+++ b/minimax_h3_rewriter/llamacpp.py
@@ -231,9 +231,19 @@ def _safe_extract(archive: str, destination: str) -> None:
             handle.extractall(destination)
         return
 
+    def link_target_inside(member: tarfile.TarInfo) -> bool:
+        # SONAME symlinks (libllama.so.0 -> libllama.so.0.0.0) ship in every
+        # official release; only a target that escapes destination is unsafe.
+        if os.path.isabs(member.linkname):
+            return False
+        target = os.path.normpath(os.path.join(os.path.dirname(member.name), member.linkname))
+        return inside(target)
+
     with tarfile.open(archive) as handle:
         for member in handle.getmembers():
-            if member.issym() or member.islnk() or not inside(member.name):
+            if not inside(member.name):
+                raise RuntimeError(f"refusing archive member outside the target: {member.name!r}")
+            if (member.issym() or member.islnk()) and not link_target_inside(member):
                 raise RuntimeError(f"refusing archive member outside the target: {member.name!r}")
         handle.extractall(destination)
 


### PR DESCRIPTION
## Summary

`_safe_extract()` in `llamacpp.py` refused **every** tar symlink/hardlink outright (`member.issym() or member.islnk()`), as a zip-slip guard. But the official Linux/macOS llama.cpp release archives ship their shared libraries as ordinary SONAME symlinks (e.g. `libllama.so.0 -> libllama.so.0.0.0`), so extraction always failed with:

```
RuntimeError: refusing archive member outside the target: 'llama-b10310/libllama.so.0'
```

on every Linux Vulkan/CPU build and the macOS build — i.e. any non-Windows install fetching the runtime for the first time.

## Fix

Only refuse a symlink/hardlink whose **target** actually resolves outside the destination directory — that's the real zip-slip risk. A same-directory SONAME symlink (or anything else that stays inside the extraction root) is allowed through, same as a regular file.

## Test plan

- [x] Reproduced the original failure on Linux (Vulkan archive) before the fix
- [x] Confirmed the archive extracts cleanly and `llama-mtmd-cli`/`llama-completion` run after the fix
- [ ] Would appreciate a check on Windows/macOS archives too, since I only have Linux to test on

🤖 Generated with [Claude Code](https://claude.com/claude-code)