### PR TITLE
feat: 'remote (llama.cpp server)' gguf_runtime — run every node against an already-running llama-server or llama-swap

### DIFF
--- a/minimax_h3_rewriter/constants.py
+++ b/minimax_h3_rewriter/constants.py
@@ -73,7 +73,15 @@ MERGE_LORA = (MERGE_AUTO, MERGE_ON, MERGE_OFF)
 RUNTIME_AUTO = "auto"
 RUNTIME_WHEEL = "llama-cpp-python"
 RUNTIME_BINARY = "llama.cpp"
-GGUF_RUNTIMES = (RUNTIME_AUTO, RUNTIME_WHEEL, RUNTIME_BINARY)
+RUNTIME_REMOTE = "remote (llama.cpp server)"
+GGUF_RUNTIMES = (RUNTIME_AUTO, RUNTIME_WHEEL, RUNTIME_BINARY, RUNTIME_REMOTE)
+
+#: Where this pack looks for an already-running llama.cpp server by default.
+#:
+#: llama-swap and a plain ``llama-server`` both speak the OpenAI-compatible
+#: chat API, so the node asks whatever is listening here. The Options node's
+#: ``server_url`` widget overrides it per workflow.
+DEFAULT_SERVER_URL = "http://127.0.0.1:9090"
 
 OUTPUT_FIELDS = (
     "integrated_multimodal_description",

--- a/minimax_h3_rewriter/mtmd_engine.py
+++ b/minimax_h3_rewriter/mtmd_engine.py
@@ -380,6 +380,8 @@ def describe(
     system_prompt: str | None = None,
     progress: NodeProgress | None = None,
     server=None,
+    remote_url: str = "",
+    remote_model: str = "",
 ) -> str:
     """Fetch the runtime if needed, describe the attachments once, and return the text.
 
@@ -401,6 +403,14 @@ def describe(
     same seed, the same instruction and the same system turn -- see
     ``DEFAULT_SYSTEM``, which is the one of those four that had to be stated
     rather than assumed -- so which one ran is not visible in the answer.
+
+    ``remote_url`` and ``remote_model`` switch the whole run to an already
+    running llama.cpp server, exactly as the rest of the pack routes text
+    generation when the Options node says 'remote (llama.cpp server)': the
+    model files, the projector and this machine's VRAM are not involved, and
+    the attachments go over the wire as content parts. ``remote_url`` being
+    set wins over ``server`` -- there is nothing to keep open when the model
+    lives elsewhere.
     """
     device = devices.validate(device)
     if system_prompt is None:
@@ -412,10 +422,6 @@ def describe(
         )
     if attachments is not None and not attachments:
         raise ValueError("nothing to describe: 'attachments' is empty.")
-
-    binary = server.binary if server is not None else llamacpp.ensure_mtmd(
-        backend, auto_download, progress
-    )
 
     with media.Workspace() as workspace:
         note = ""
@@ -431,6 +437,36 @@ def describe(
             ]
         if note:
             instruction = f"{note}\n\n{instruction}"
+
+        if remote_url:
+            from . import remote_engine
+
+            if progress is not None:
+                progress.text(
+                    f"Describing on {remote_engine.normalize_url(remote_url)}\n"
+                    f"{' + '.join(notes)}",
+                    force=True,
+                )
+            text = remote_engine.caption(
+                instruction=instruction,
+                attachments=attachments,
+                system_prompt=system_prompt,
+                server_url=remote_url,
+                server_model=remote_model,
+                seed=seed,
+                greedy=greedy,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                media_marker=None,
+                progress=progress,
+            )
+            return answer_only(text.replace("\r\n", "\n"))
+
+        binary = server.binary if server is not None else llamacpp.ensure_mtmd(
+            backend, auto_download, progress
+        )
 
         command = None
         if server is None:

--- a/minimax_h3_rewriter/multi_caption.py
+++ b/minimax_h3_rewriter/multi_caption.py
@@ -30,6 +30,7 @@ its nodes, so an old install loses this node alone instead of all of them.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass
 
@@ -48,9 +49,12 @@ from .nodes import (
     caption_question,
     captioner_choices,
     next_index,
+    remote_target,
     slot_instructions,
 )
 from .progress import NodeProgress
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -398,16 +402,22 @@ class MiniMaxH3MultiReferenceCaption(io.ComfyNode):
 
         kinds = {asset.kind for asset in assets}
         model_path = mmproj_path = None
+        target = remote_target(settings)
+        remote_url = target[0] if target else ""
+        remote_model = target[1] if target else ""
         if described > 0 and clip is None:
-            choice = _resolve_captioner_choice(model)
-            if choice.local:
-                model_path, mmproj_path = choice.reference, choice.mmproj
+            if target is not None:
+                model_path = mmproj_path = ""
             else:
-                model_path, mmproj_path = _ensure_pair(
-                    choice.reference, choice.file, choice.mmproj, "Captioner",
-                    settings["auto_download"], progress,
-                )
-            _check_encoders(mmproj_path, kinds)
+                choice = _resolve_captioner_choice(model)
+                if choice.local:
+                    model_path, mmproj_path = choice.reference, choice.mmproj
+                else:
+                    model_path, mmproj_path = _ensure_pair(
+                        choice.reference, choice.file, choice.mmproj, "Captioner",
+                        settings["auto_download"], progress,
+                    )
+                _check_encoders(mmproj_path, kinds)
         elif described > 0:
             clip_caption.check(clip, kinds)
 
@@ -478,6 +488,8 @@ class MiniMaxH3MultiReferenceCaption(io.ComfyNode):
                             auto_download=settings["auto_download"],
                             progress=progress,
                             server=batch,
+                            remote_url=remote_url,
+                            remote_model=remote_model,
                         )
 
                 caption = " ".join(caption.split())

--- a/minimax_h3_rewriter/nodes.py
+++ b/minimax_h3_rewriter/nodes.py
@@ -28,6 +28,7 @@ from . import (
     memory,
     mtmd_engine,
     ollama_store,
+    remote_engine,
     repair,
 )
 from .catalog import FORMAT_GGUF, FORMAT_TRANSFORMERS
@@ -37,6 +38,7 @@ from .constants import (
     ATTN_IMPLEMENTATIONS,
     BASE_MODEL_REPO,
     BASE_SKIP_SUFFIXES,
+    DEFAULT_SERVER_URL,
     GGUF_RUNTIMES,
     MERGE_AUTO,
     MERGE_LORA,
@@ -47,6 +49,7 @@ from .constants import (
     RESOLUTIONS,
     RUNTIME_AUTO,
     RUNTIME_BINARY,
+    RUNTIME_REMOTE,
     RUNTIME_WHEEL,
     duration_widget,
 )
@@ -82,12 +85,35 @@ DEFAULT_OPTIONS = {
     "n_ctx": 8192,
     "gguf_runtime": RUNTIME_AUTO,
     "llama_backend": "auto",
+    "server_url": DEFAULT_SERVER_URL,
+    "server_model": "",
     "device": devices.AUTO,
     "trust_remote_code": False,
     "prompt_file": library.DEFAULT_FILE,
     "self_check": checks.REPORT_ALL,
     "fix_once": False,
 }
+
+LOCAL_PREFIX = "on disk: "
+
+OLLAMA_PREFIX = "ollama: "
+
+
+def remote_target(settings: dict) -> tuple[str, str] | None:
+    """``(server_url, server_model)`` when the run is to go over the wire, else None.
+
+    The one place the decision is made, so the text nodes, the captioners and
+    the frame-carrying writers all agree without repeating it: the Options
+    node picks 'remote (llama.cpp server)' as the ``gguf_runtime`` and every
+    local engine -- the wheel, the binaries, the downloads, the VRAM -- stops
+    being involved. The model the local list names is ignored, because the
+    server already holds one; ``server_model`` is its name, or empty to let
+    the server decide.
+    """
+    if not (settings or {}).get("gguf_runtime") == RUNTIME_REMOTE:
+        return None
+    return remote_engine.normalize_url(settings.get("server_url")), remote_engine.server_model(settings)
+
 
 BASE_SPEC = {
     "default_repo": BASE_MODEL_REPO,
@@ -103,10 +129,6 @@ ADAPTER_SPEC = {
     "skip_suffixes": (),
     "label": "Prompt-rewriter LoRA",
 }
-
-LOCAL_PREFIX = "on disk: "
-
-OLLAMA_PREFIX = "ollama: "
 
 
 @dataclass
@@ -675,9 +697,17 @@ def _gguf_text(settings: dict, **common) -> str:
 
     Both rewriters ask the same question -- resident wheel, or the official
     binaries in a subprocess -- and the answer does not depend on which of them
-    is asking, so it is answered once.
+    is asking, so it is answered once. The remote server is a third answer, and
+    it is reached before the question is asked: once the Options node points at
+    one, the local engines are not in the running at all.
     """
     runtime = settings.get("gguf_runtime", RUNTIME_AUTO)
+    if runtime == RUNTIME_REMOTE:
+        return remote_engine.rewrite(
+            server_url=settings.get("server_url"),
+            server_model=settings.get("server_model"),
+            **common,
+        )
     if runtime == RUNTIME_AUTO:
         runtime = RUNTIME_WHEEL if gguf_engine.available() else RUNTIME_BINARY
 
@@ -789,11 +819,45 @@ class MiniMaxH3RewriterOptions:
                     {
                         "default": RUNTIME_AUTO,
                         "tooltip": (
-                            "GGUF only: what runs the model. 'auto' uses llama-cpp-python when "
+                            "What runs the GGUF models. 'auto' uses llama-cpp-python when "
                             "it is importable and the official llama.cpp binaries otherwise. "
                             "Force 'llama.cpp' if an installed wheel is broken; force "
-                            "'llama-cpp-python' to keep the model resident between runs, which "
-                            "the binaries cannot do."
+                            "'llama-cpp-python' to keep the model resident between runs, "
+                            "which the binaries cannot do.\n\n"
+                            "'remote (llama.cpp server)' runs none of it: the messages go "
+                            "over HTTP to an already-running 'llama-server' or llama-swap at "
+                            "'server_url' -- llama-swap's default is '127.0.0.1:9090'. "
+                            "Nothing is downloaded, nothing is loaded here, the model and "
+                            "its LoRA are whatever the server holds, and 'server_model' "
+                            "names which one to ask for when the server serves several."
+                        ),
+                    },
+                ),
+                "server_url": (
+                    "STRING",
+                    {
+                        "default": DEFAULT_SERVER_URL,
+                        "tooltip": (
+                            "Where the llama.cpp server listens, for 'remote (llama.cpp "
+                            "server)' only. llama-swap -- a model-swapping proxy around "
+                            "llama-server -- listens on '127.0.0.1:9090' by default; a "
+                            "plain 'llama-server' listens on '127.0.0.1:8080'. Give the "
+                            "base address only; the node appends /v1/chat/completions."
+                        ),
+                    },
+                ),
+                "server_model": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "Which model on the server to ask for, for 'remote (llama.cpp "
+                            "server)' only. llama-swap switches to whatever model this names "
+                            "and loads it if needed; a plain 'llama-server' holds one model "
+                            "and ignores the field, which is what an empty value achieves. "
+                            "The model's LoRA travels with it -- a server-served rewriter "
+                            "already has the prompt-rewriter LoRA attached, which is why "
+                            "'use_lora' is ignored here."
                         ),
                     },
                 ),
@@ -959,8 +1023,6 @@ def rewrite_t2va(
     the same either way, and the second copy of it would be the one that stopped
     getting fixed.
     """
-    choice = _resolve_model_choice(model)
-
     decoding = {
         "messages": build_messages(prompt, resolution, float(duration)),
         "seed": int(seed),
@@ -971,6 +1033,11 @@ def rewrite_t2va(
         "top_k": int(settings["top_k"]),
         "repetition_penalty": float(settings["repetition_penalty"]),
     }
+
+    if settings.get("gguf_runtime") == RUNTIME_REMOTE:
+        return _gguf_text(settings, progress=progress, **decoding)
+
+    choice = _resolve_model_choice(model)
 
     if choice.fmt == FORMAT_GGUF:
         if choice.local:
@@ -1241,6 +1308,21 @@ def run_messages(
 
     ``label`` only names the caller in the log line and the caption.
     """
+    if settings.get("gguf_runtime") == RUNTIME_REMOTE:
+        return remote_engine.rewrite(
+            messages=messages,
+            server_url=settings.get("server_url"),
+            server_model=settings.get("server_model"),
+            seed=int(seed),
+            greedy=greedy,
+            max_new_tokens=int(settings["max_new_tokens"]),
+            temperature=float(settings["temperature"]),
+            top_p=float(settings["top_p"]),
+            top_k=int(settings["top_k"]),
+            repetition_penalty=float(settings["repetition_penalty"]),
+            progress=progress,
+            label=label,
+        )
     choice = _resolve_writer_choice(model)
     if choice.local:
         model_path = choice.reference
@@ -2319,49 +2401,75 @@ class MiniMaxH3ReferenceCaption:
                     progress=progress,
                 )
             else:
-                choice = _resolve_captioner_choice(model)
-                if choice.local:
-                    model_path, mmproj_path = choice.reference, choice.mmproj
+                target = remote_target(settings)
+                if target is not None:
+                    caption = mtmd_engine.describe(
+                        model_path="",
+                        mmproj_path="",
+                        instruction=asked,
+                        image=image,
+                        audio=audio,
+                        video=video,
+                        max_frames=int(max_frames),
+                        gpu_layers=int(settings["gpu_layers"]),
+                        n_ctx=int(context_size),
+                        seed=int(seed),
+                        greedy=True,
+                        max_new_tokens=min(int(settings["max_new_tokens"]), 1024),
+                        temperature=float(settings["temperature"]),
+                        top_p=float(settings["top_p"]),
+                        top_k=int(settings["top_k"]),
+                        device=settings["device"],
+                        backend=settings["llama_backend"],
+                        auto_download=False,
+                        progress=progress,
+                        remote_url=target[0],
+                        remote_model=target[1],
+                    )
                 else:
-                    model_path, mmproj_path = _ensure_pair(
-                        choice.reference, choice.file, choice.mmproj, "Captioner",
-                        settings["auto_download"], progress,
-                    )
+                    choice = _resolve_captioner_choice(model)
+                    if choice.local:
+                        model_path, mmproj_path = choice.reference, choice.mmproj
+                    else:
+                        model_path, mmproj_path = _ensure_pair(
+                            choice.reference, choice.file, choice.mmproj, "Captioner",
+                            settings["auto_download"], progress,
+                        )
 
-                header = discovery.gguf_header(mmproj_path)
-                if audio is not None and not header["audio"]:
-                    raise RuntimeError(
-                        f"'{os.path.basename(mmproj_path)}' was built without an audio encoder, so "
-                        f"this model cannot hear the clip. Pick a captioner whose label lists "
-                        f"'audio'."
-                    )
-                if (image is not None or video is not None) and not header["vision"]:
-                    raise RuntimeError(
-                        f"'{os.path.basename(mmproj_path)}' was built without a vision encoder, so "
-                        f"this model cannot see. Pick a captioner whose label lists 'vision'."
-                    )
+                    header = discovery.gguf_header(mmproj_path)
+                    if audio is not None and not header["audio"]:
+                        raise RuntimeError(
+                            f"'{os.path.basename(mmproj_path)}' was built without an audio encoder, so "
+                            f"this model cannot hear the clip. Pick a captioner whose label lists "
+                            f"'audio'."
+                        )
+                    if (image is not None or video is not None) and not header["vision"]:
+                        raise RuntimeError(
+                            f"'{os.path.basename(mmproj_path)}' was built without a vision encoder, so "
+                            f"this model cannot see. Pick a captioner whose label lists 'vision'."
+                        )
 
-                caption = mtmd_engine.describe(
-                    model_path=model_path,
-                    mmproj_path=mmproj_path,
-                    instruction=asked,
-                    image=image,
-                    audio=audio,
-                    video=video,
-                    max_frames=int(max_frames),
-                    gpu_layers=int(settings["gpu_layers"]),
-                    n_ctx=int(context_size),
-                    seed=int(seed),
-                    greedy=True,
-                    max_new_tokens=min(int(settings["max_new_tokens"]), 1024),
-                    temperature=float(settings["temperature"]),
-                    top_p=float(settings["top_p"]),
-                    top_k=int(settings["top_k"]),
-                    device=settings["device"],
-                    backend=settings["llama_backend"],
-                    auto_download=settings["auto_download"],
-                    progress=progress,
-                )
+                    caption = mtmd_engine.describe(
+                        model_path=model_path,
+                        mmproj_path=mmproj_path,
+                        instruction=asked,
+                        image=image,
+                        audio=audio,
+                        video=video,
+                        max_frames=int(max_frames),
+                        gpu_layers=int(settings["gpu_layers"]),
+                        n_ctx=int(context_size),
+                        seed=int(seed),
+                        greedy=True,
+                        max_new_tokens=min(int(settings["max_new_tokens"]), 1024),
+                        temperature=float(settings["temperature"]),
+                        top_p=float(settings["top_p"]),
+                        top_k=int(settings["top_k"]),
+                        device=settings["device"],
+                        backend=settings["llama_backend"],
+                        auto_download=settings["auto_download"],
+                        progress=progress,
+                    )
             memory.keep(
                 unique_id, "MiniMaxH3ReferenceCaption", (caption,), given, task="caption"
             )

--- a/minimax_h3_rewriter/remote_engine.py
+++ b/minimax_h3_rewriter/remote_engine.py
@@ -1,0 +1,399 @@
+"""Generating through an already-running llama.cpp server.
+
+Every other backend in this pack carries the model on the ComfyUI machine: a
+transformers checkpoint in this process, a llama-cpp-python wheel, or the
+official binaries in a subprocess. This one runs none of it. ``llama-server``
+and llama-swap both speak the OpenAI-compatible chat API, so the node sends the
+messages over HTTP and reads the streamed answer back -- the weights, the KV
+cache and the sampling all live wherever ``server_url`` points, which may be
+another process, another card or another machine entirely.
+
+What that buys is decided on the Options node. Pick 'remote (llama.cpp
+server)' as the ``gguf_runtime`` and:
+
+- **Nothing is downloaded and nothing is loaded here.** ``model_path``,
+  ``adapter_path``, ``gpu_layers``, ``n_ctx`` and ``keep_model_loaded`` stop
+  meaning anything: the files and flags they name live on the server, and the
+  LoRA is whatever the serving model has attached, so ``use_lora`` is likewise
+  a no-op. A rewrite still fills the progress bar the same way, because the
+  tokens still stream through this process.
+- **The chat template is the server's.** The messages are handed over as roles
+  and content, and the server applies its model's own template -- which is
+  also what lets `caption` send pictures and sounds as content parts, exactly
+  like the local ``llama-server`` path in ``server_engine``.
+- **The context is the server's.** ``n_ctx`` is honoured or not by whichever
+  server answers; this side cannot widen it, so ``run_messages`` skips its
+  local widening entirely.
+
+The failure mode worth naming is that a missing server is a missing answer:
+an endpoint that does not answer raises rather than falling back to a local
+backend, because quietly spending a five-gigabyte download on the *other* side
+of a typo is into the same category of surprise the rest of this pack refuses.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+
+from . import checks, runner
+from .constants import normalize_seed
+from .progress import NodeProgress
+
+log = logging.getLogger(__name__)
+
+DEFAULT_SERVER_URL = "http://127.0.0.1:9090"
+
+PREVIEW_TAIL = 280
+
+CHARS_PER_TOKEN = 4.0
+
+LOOP_EVERY = 32
+
+REQUEST_SECONDS = 900.0
+
+MEDIA_TYPE = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+              ".webp": "image/webp", ".gif": "image/gif", ".bmp": "image/bmp"}
+
+
+def normalize_url(value: str) -> str:
+    """A base URL without a trailing slash, or a refusal naming the default."""
+    value = (value or "").strip().strip('"')
+    if not value:
+        return DEFAULT_SERVER_URL
+    if "://" not in value:
+        raise RuntimeError(
+            f"server_url is '{value}', which is not an address like "
+            f"'{DEFAULT_SERVER_URL}'. Give the scheme and the port -- 'http://' or "
+            f"'https://' -- and leave off any path; the node appends "
+            f"/v1/chat/completions itself."
+        )
+    return value.rstrip("/")
+
+
+def server_model(settings: dict) -> str:
+    """Which model on the server to ask for, or '' to let the server decide.
+
+    llama-swap picks a model from the ``model`` field of each request; left
+    empty, it serves whatever it was told to swap to by default. A plain
+    ``llama-server`` ignores the field, which is exactly what an empty value
+    achieves here.
+    """
+    return (settings.get("server_model") or "").strip()
+
+
+def reachable(url: str, timeout: float = 2.0) -> bool:
+    """Whether something that speaks the OpenAI API is listening at ``url``."""
+    try:
+        request = urllib.request.Request(f"{normalize_url(url)}/v1/models")
+        with urllib.request.urlopen(request, timeout=timeout) as answer:
+            return answer.status == 200
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def models(url: str) -> list[str]:
+    """The model names the server offers, or [] when it will not say.
+
+    llama-swap answers ``/v1/models`` with what it can swap to; a plain
+    llama.cpp server answers with the single model it holds. Called only for
+    the log line -- the request itself is sent with whatever ``server_model``
+    says, because the list is advisory and the truthful unit test is the chat
+    call that follows.
+    """
+    try:
+        request = urllib.request.Request(f"{normalize_url(url)}/v1/models")
+        with urllib.request.urlopen(request, timeout=5) as answer:
+            payload = json.loads(answer.read().decode("utf-8", errors="replace"))
+        return [entry.get("id") or "" for entry in payload.get("data") or [] if entry.get("id")]
+    except (urllib.error.URLError, OSError, ValueError):
+        return []
+
+
+def _unreachable(url: str) -> RuntimeError:
+    return RuntimeError(
+        f"The llama.cpp server at '{normalize_url(url)}' did not answer. Is llama-swap (or "
+        f"llama-server) actually running on that address? The default is "
+        f"'{DEFAULT_SERVER_URL}'; the Options node's 'server_url' field says anything else. "
+        f"Check the port, and that the server process is the one you think it is -- this "
+        f"node is pointing at a service, and a service that is not there is a dead run."
+    )
+
+
+def _media_part(kind: str, path: str) -> dict:
+    """One attachment as an OpenAI content part, exactly as ``server_engine`` sends it.
+
+    A picture goes in as a base64 data URI, a sound as an ``input_audio``
+    part. This is the only wire format the server offers to its projector, so
+    the canonical implementation lives in one place more than it would like:
+    any change here should check ``server_engine.content_parts`` too.
+    """
+    if kind == "image":
+        mediatype = MEDIA_TYPE.get(os.path.splitext(path)[1].lower(), "image/png")
+        with open(path, "rb") as handle:
+            uri = "data:" + mediatype + ";base64," + base64.b64encode(handle.read()).decode("ascii")
+        return {"type": "image_url", "image_url": {"url": uri}}
+    if kind == "audio":
+        with open(path, "rb") as handle:
+            encoded = base64.b64encode(handle.read()).decode("ascii")
+        return {"type": "input_audio", "input_audio": {"data": encoded, "format": "wav"}}
+    raise ValueError(f"unknown attachment kind '{kind}'")
+
+
+def content_parts(
+    instruction: str, attachments: list[tuple[str, str]], media_marker: str | None = None
+) -> list[dict]:
+    """The user turn as content parts, media in the order it was attached.
+
+    With ``media_marker`` given and present in the instruction -- which is how
+    the 8B and Omni writers build their turns -- each marker is replaced by the
+    next attachment in order, so a picture stays attached to the text naming
+    it, the same way ``llama-mtmd-cli`` splices the frames in at the markers.
+    Without it the media line up first and the instruction follows, which is
+    what ``server_engine`` does and what a caption's plain question needs.
+    """
+    if media_marker and media_marker in instruction:
+        remaining = list(attachments)
+        parts: list[dict] = []
+        for chunk in instruction.split(media_marker):
+            if chunk:
+                parts.append({"type": "text", "text": chunk})
+            if remaining:
+                parts.append(_media_part(*remaining.pop(0)))
+        return parts
+    parts = [_media_part(kind, path) for kind, path in attachments]
+    parts.append({"type": "text", "text": instruction})
+    return parts
+
+
+def _delta(raw: bytes) -> str:
+    """One token's worth of text out of a server-sent-events line, or ""."""
+    line = raw.decode("utf-8", errors="replace").strip()
+    if not line.startswith("data:"):
+        return ""
+    payload = line[5:].strip()
+    if not payload or payload == "[DONE]":
+        return ""
+    try:
+        parsed = json.loads(payload)
+    except ValueError:
+        log.debug("[minimax_h3_rewriter.remote_engine._delta] unparsed: %.120s", payload)
+        return ""
+    choices = parsed.get("choices") or [{}]
+    return (choices[0].get("delta") or {}).get("content") or ""
+
+
+def _sampling(
+    seed: int,
+    greedy: bool,
+    max_new_tokens: int,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    repetition_penalty: float,
+) -> dict:
+    """The request body's sampling half, in the spelling llama.cpp speaks.
+
+    ``top_k`` and ``repeat_penalty`` are what the server calls them, not the
+    OpenAI names for their nearest equivalents, so the body is built here
+    rather than by an OpenAI client halfway to translating.
+
+    ``chat_template_kwargs`` carries the thinking switch, the same
+    ``enable_thinking=False`` the pack passes to every local run: without it a
+    reasoning model spends the whole token ceiling on ``reasoning_content`` and
+    the ``content`` field comes back empty, which is not a rewrite anyone
+    asked for. Newer llama.cpp servers understand the key and older ones ignore
+    it, and the direction that fails safely is the one that asks.
+    """
+    body = {
+        "max_tokens": int(max_new_tokens),
+        "repeat_penalty": float(repetition_penalty),
+        "seed": normalize_seed(seed),
+        "stream": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    if greedy:
+        body["temperature"] = 0.0
+    else:
+        body.update(
+            temperature=float(temperature),
+            top_p=float(top_p),
+            top_k=int(top_k),
+        )
+    return body
+
+
+def _chat(
+    messages: list[dict],
+    url: str,
+    model: str,
+    body: dict,
+    progress: NodeProgress | None = None,
+    on_text=None,
+) -> str:
+    """POST the chat completion and read the streamed answer back.
+
+    ``on_text`` follows ``run_messages`` and the other engines' callbacks:
+    called with the whole answer so far, and returning something truthy ends
+    the request and keeps what was written. Loop detection runs whether or not
+    there is a bar to draw.
+    """
+    request = urllib.request.Request(
+        f"{url}/v1/chat/completions",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    pieces: list[str] = []
+    produced = 0
+    interrupted = False
+    looped = False
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_SECONDS) as answer:
+            for raw in answer:
+                if runner.interrupted():
+                    interrupted = True
+                    break
+                piece = _delta(raw)
+                if not piece:
+                    continue
+                pieces.append(piece)
+                produced += 1
+                if on_text is not None and on_text("".join(pieces)):
+                    log.info("[minimax_h3_rewriter.remote_engine] answer stopped early by the caller")
+                    break
+                if produced % LOOP_EVERY == 0 and checks.looping("".join(pieces)):
+                    looped = True
+                    log.info(
+                        "[minimax_h3_rewriter.remote_engine] stopping at a repetition after %d tokens",
+                        produced,
+                    )
+                    break
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")[:600]
+        raise RuntimeError(
+            f"The server at '{url}' refused the request ({error.code}): {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise _unreachable(url) from error
+    except OSError as error:
+        raise _unreachable(url) from error
+
+    if interrupted:
+        import comfy.model_management as mm
+
+        raise mm.InterruptProcessingException()
+
+    if progress is not None:
+        if looped:
+            progress.finish(f"Stopped at a repetition · {produced} tokens")
+        else:
+            progress.finish(f"Done · {produced} tokens")
+    return "".join(pieces).strip()
+
+
+def rewrite(
+    messages: list[dict[str, str]],
+    server_url: str = DEFAULT_SERVER_URL,
+    server_model: str = "",
+    seed: int = 42,
+    greedy: bool = True,
+    max_new_tokens: int = 2048,
+    temperature: float = 0.7,
+    top_p: float = 0.8,
+    top_k: int = 20,
+    repetition_penalty: float = 1.05,
+    progress: NodeProgress | None = None,
+    label: str = "",
+    **ignored,
+) -> str:
+    """One text completion against ``server_url``, and the answer alone.
+
+    ``**ignored`` picks up everything the local engines take that a server has
+    already decided -- ``model_path``, ``adapter_path``, ``gpu_layers``,
+    ``n_ctx``, ``keep_loaded``, ``device`` -- so ``_gguf_text`` and
+    ``run_messages`` can hand the same call straight over.
+    """
+    url = normalize_url(server_url)
+    name = (server_model or "").strip()
+    if progress is not None:
+        progress.set_total(max(int(max_new_tokens), 1))
+        title = f"{label + ': ' if label else ''}Generating on {url}"
+        title += f" · {name}" if name else ""
+        progress.update(0, f"{title}\n0 tokens")
+
+    def report(whole: str) -> bool:
+        """Drive the bar; the loop check runs in ``_chat`` either way."""
+        if progress is not None:
+            progress.update(
+                min(len(whole) / CHARS_PER_TOKEN, float(max_new_tokens)),
+                f"{label + ': ' if label else ''}{len(whole)} chars\n{whole[-PREVIEW_TAIL:]}",
+            )
+        return False
+
+    body = {
+        "messages": list(messages),
+        **_sampling(seed, greedy, max_new_tokens, temperature, top_p, top_k, repetition_penalty),
+    }
+    if name:
+        body["model"] = name
+
+    return _chat(messages, url, name, body, progress, report)
+
+
+def caption(
+    instruction: str,
+    attachments: list[tuple[str, str]],
+    system_prompt: str = "",
+    server_url: str = DEFAULT_SERVER_URL,
+    server_model: str = "",
+    seed: int = 42,
+    greedy: bool = True,
+    max_new_tokens: int = 256,
+    temperature: float = 0.7,
+    top_p: float = 0.8,
+    top_k: int = 20,
+    repetition_penalty: float = 1.05,
+    media_marker: str | None = None,
+    progress: NodeProgress | None = None,
+) -> str:
+    """Describe the attachments against ``server_url``, media in order.
+
+    The wire shape is what ``server_engine`` already speaks to a locally-run
+    ``llama-server``: the user turn is content parts, with pictures as base64
+    data URIs and sounds as ``input_audio``. `media_marker` lets a turn whose
+    text names the assets splice each one in next to the sentence naming it,
+    which is how the frame-carrying writers arrive here.
+    """
+    url = normalize_url(server_url)
+    name = (server_model or "").strip()
+
+    messages: list[dict] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": content_parts(instruction, attachments, media_marker)})
+
+    body = {
+        "messages": messages,
+        **_sampling(seed, greedy, max_new_tokens, temperature, top_p, top_k, repetition_penalty),
+    }
+    if name:
+        body["model"] = name
+
+    if progress is not None:
+        progress.set_total(max(int(max_new_tokens), 1))
+        progress.update(0, f"Describing on {url} · {len(attachments)} attachment(s)\n0 tokens")
+
+    def report(whole: str) -> bool:
+        if progress is not None:
+            progress.update(
+                min(len(whole) / CHARS_PER_TOKEN, float(max_new_tokens)),
+                f"Describing · {len(whole)} chars\n{whole[-PREVIEW_TAIL:]}",
+            )
+        return False
+
+    return _chat(messages, url, name, body, progress, report)

--- a/minimax_h3_rewriter/universal.py
+++ b/minimax_h3_rewriter/universal.py
@@ -66,6 +66,7 @@ from .nodes import (
     caption_question,
     captioner_choices,
     next_index,
+    remote_target,
     slot_instructions,
     writer_choices,
 )
@@ -595,16 +596,22 @@ class MiniMaxH3UniversalWriter(io.ComfyNode):
         if assets:
             kinds = {asset.kind for asset in assets}
             model_path = mmproj_path = None
+            target = remote_target(settings)
+            remote_url = target[0] if target else ""
+            remote_model = target[1] if target else ""
             if clip is None:
-                choice = _resolve_captioner_choice(caption_model)
-                if choice.local:
-                    model_path, mmproj_path = choice.reference, choice.mmproj
+                if target is not None:
+                    model_path = mmproj_path = ""
                 else:
-                    model_path, mmproj_path = _ensure_pair(
-                        choice.reference, choice.file, choice.mmproj, "Captioner",
-                        settings["auto_download"], progress,
-                    )
-                _check_encoders(mmproj_path, kinds)
+                    choice = _resolve_captioner_choice(caption_model)
+                    if choice.local:
+                        model_path, mmproj_path = choice.reference, choice.mmproj
+                    else:
+                        model_path, mmproj_path = _ensure_pair(
+                            choice.reference, choice.file, choice.mmproj, "Captioner",
+                            settings["auto_download"], progress,
+                        )
+                    _check_encoders(mmproj_path, kinds)
             else:
                 clip_caption.check(clip, kinds)
 
@@ -676,6 +683,8 @@ class MiniMaxH3UniversalWriter(io.ComfyNode):
                             auto_download=settings["auto_download"],
                             progress=progress,
                             server=batch,
+                            remote_url=remote_url,
+                            remote_model=remote_model,
                         )
 
                     caption = " ".join(caption.split())

--- a/minimax_h3_rewriter/writer_8b.py
+++ b/minimax_h3_rewriter/writer_8b.py
@@ -57,6 +57,7 @@ from .nodes import (
     _report,
     _resolve_adapter,
     _verify_base_model,
+    remote_target,
 )
 from .progress import NodeProgress, announce
 from .prompt_template_8b import build_messages, expected_image_count, normalize_task
@@ -311,6 +312,7 @@ def _with_transformers(
 def _with_frames(
     frames, model_path, mmproj_path, adapter_path, system, user,
     settings, seed, greedy, keep_loaded, progress,
+    target=None,
 ) -> str:
     """Run the multimodal path: one picture per marker, in order."""
     if keep_loaded:
@@ -346,6 +348,8 @@ def _with_frames(
             backend=settings["llama_backend"],
             auto_download=settings["auto_download"],
             progress=progress,
+            remote_url=(target[0] if target else ""),
+            remote_model=(target[1] if target else ""),
         )
 
 
@@ -372,6 +376,30 @@ def rewrite_8b(
     """
     wanted = normalize_task(task)
     frames = frames_for(wanted, first_frame, last_frame, progress)
+
+    target = remote_target(settings)
+    if target is not None:
+        system, user = render(build_messages(prompt, wanted, resolution, duration))
+        decoding = dict(
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            seed=int(seed),
+            greedy=greedy,
+            max_new_tokens=int(settings["max_new_tokens"]),
+            temperature=float(settings["temperature"]),
+            top_p=float(settings["top_p"]),
+            top_k=int(settings["top_k"]),
+            repetition_penalty=float(settings["repetition_penalty"]),
+        )
+        if frames:
+            return _with_frames(
+                frames, "", "", None, system, user, settings, seed, greedy,
+                keep_loaded, progress, target,
+            )
+        return _gguf_text(settings, progress=progress, **decoding)
+
     choice = _resolve_model_choice(model)
 
     if choice.fmt == FORMAT_TRANSFORMERS:

--- a/minimax_h3_rewriter/writer_omni.py
+++ b/minimax_h3_rewriter/writer_omni.py
@@ -74,6 +74,7 @@ from .nodes import (
     _report,
     _resolve_adapter,
     _verify_base_model,
+    remote_target,
 )
 from .progress import NodeProgress, refuse
 from .prompt_template_omni import (
@@ -469,6 +470,7 @@ def _room_for(n_ctx: int, budget: int, model_path: str, progress: NodeProgress) 
 def _with_media(
     references, model_path, mmproj_path, adapter_path, messages,
     settings, seed, greedy, keep_loaded, max_frames, progress,
+    target=None,
 ) -> str:
     """Run the multimodal path: one asset per marker, in order."""
     if keep_loaded:
@@ -494,7 +496,10 @@ def _with_media(
             attachments=attachments,
             adapter_path=adapter_path,
             gpu_layers=int(settings["gpu_layers"]),
-            n_ctx=_room_for(int(settings["n_ctx"]), budget, model_path, progress),
+            n_ctx=(
+                _room_for(int(settings["n_ctx"]), budget, model_path, progress)
+                if not target else int(settings["n_ctx"])
+            ),
             seed=int(seed),
             greedy=greedy,
             max_new_tokens=int(settings["max_new_tokens"]),
@@ -505,6 +510,8 @@ def _with_media(
             backend=settings["llama_backend"],
             auto_download=settings["auto_download"],
             progress=progress,
+            remote_url=(target[0] if target else ""),
+            remote_model=(target[1] if target else ""),
         )
 
 
@@ -532,6 +539,37 @@ def rewrite_omni(
     wanted = normalize_task(task)
     references = list(references or [])
     check_task(wanted, references, progress.node_id)
+
+    target = remote_target(settings)
+    if target is not None:
+        messages = build_messages(
+            prompt, wanted, resolution, float(duration), tuple(r.kind for r in references)
+        )
+        decoding = dict(
+            seed=int(seed),
+            greedy=greedy,
+            max_new_tokens=int(settings["max_new_tokens"]),
+            temperature=float(settings["temperature"]),
+            top_p=float(settings["top_p"]),
+            top_k=int(settings["top_k"]),
+            repetition_penalty=float(settings["repetition_penalty"]),
+        )
+        if references:
+            return _with_media(
+                references, "", "", None, messages,
+                settings, seed, greedy, keep_loaded, max_frames, progress, target,
+            )
+        system, user = render(messages)
+        return _gguf_text(
+            settings,
+            progress=progress,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            **decoding,
+        )
+
     choice = _resolve_model_choice(model)
 
     if choice.fmt == FORMAT_TRANSFORMERS:


### PR DESCRIPTION
## Summary

Adds a fourth `gguf_runtime`, **`remote (llama.cpp server)`**, that sends the messages over HTTP instead of running any of the model locally: the model files, the LoRA, the KV cache and the GPU all belong to whatever answers `server_url`. Since `llama-server` and llama-swap both speak the OpenAI-compatible chat API, the natural target is llama-swap (its default `127.0.0.1:9090` is the default `server_url`), and a plain `llama-server` works the same way.

Nothing is downloaded and nothing is loaded in ComfyUI in this mode — no `llama-cpp-python`, no fetched llama.cpp binaries, no Transformers load, no VRAM. This is the way to use a model already resident in a llama.cpp server (e.g. pointing at an abliterated/heretic build loaded with the prompt-rewriter LoRA server-side).

## What it changes

**New module `minimax_h3_rewriter/remote_engine.py`** — a small OpenAI-compatible client:

- `rewrite()` — text completion used by the 27B rewriter, the guided writers, the universal writer and the reducer. Chat-template rendering and the context belong to the server, so `n_ctx` / `gpu_layers` / `device` / `keep_model_loaded` stop mattering and the remote branch is reached **before** any local model resolution.
- `caption()` — the multimodal route for the captioners and the frame-carrying 8B/Omni writers: pictures as base64 data URIs, sounds as `input_audio` content parts — the same wire shape `server_engine` already uses for a locally spawned `llama-server`. A `media_marker` in a written turn splices each attachment in next to the sentence naming it, matching how `llama-mtmd-cli` interleaves frames.
- Both stream the answer, drive the node progress bar, honour ComfyUI interrupts and run the same repetition stop as the local engines; a missing/refusing server raises a readable error.

**Options node** gains two widgets:
- `server_url` — default `http://127.0.0.1:9090`
- `server_model` — empty lets llama-swap serve its default; a name makes it swap to (and load) that model on demand

`use_lora`, the adapter field and the model dropdowns are ignored in this mode, since the served model carries its own adapter.

**Wiring** — `remote_target()` is the single decision point shared by the text nodes, the caption node, the multi/universal captioners and both frame-carrying writers; `mtmd_engine.describe()` accepts `remote_url`/`remote_model` and takes that path before any local binary or server session is considered. Local context widening is skipped when the server owns the context.

## Notable details found on a live llama-swap

Reasoning-capable served models (every `-heretic`/`-ablit` build answers as a thinker) spend the whole token ceiling on `reasoning_content` and return an **empty** `content` field unless the request carries `chat_template_kwargs: {"enable_thinking": false}`. The body always sends it — the same thinking suppression the pack applies to every local run.

## Verification

Live against llama-swap at `127.0.0.1:9090`:

- text rewrite through `Qwen3.5-4B-ablit` streams back correctly
- image caption through `joycaption-beta-one-llava` describes the picture
- a server refusing a request (vision model served without its `mmproj`) raises a readable error instead of dead-ending

All 391 existing tests pass. No docs/tests were added for the remote path — happy to follow the repo's conventions for them if wanted.